### PR TITLE
Fix signal lock when compiled with -O2 or -O3

### DIFF
--- a/spdif_rx.c
+++ b/spdif_rx.c
@@ -216,6 +216,10 @@ static inline uint32_t* _to_buff_ptr(uint32_t ptr)
 __attribute__((weak))
 void spdif_rx_callback_func(uint32_t* buff, uint32_t sub_frame_count, uint8_t c_bits[SPDIF_BLOCK_SIZE / 16], bool parity_err)
 {
+    (void) buff;
+    (void) sub_frame_count;
+    (void) c_bits;
+    (void) parity_err;
     return;
 }
 
@@ -435,6 +439,9 @@ static void _spdif_rx_common_end()
 
 static int64_t _spdif_rx_capture_timeout(alarm_id_t id, void* user_data)
 {
+    (void) id;
+    (void) user_data;
+
     _clear_timer();
     _spdif_rx_common_end();
     _set_timer_after_by_ms(_spdif_rx_capture_retry, capture_retry_interval_ms);
@@ -443,6 +450,9 @@ static int64_t _spdif_rx_capture_timeout(alarm_id_t id, void* user_data)
 
 static int64_t _spdif_rx_capture_retry(alarm_id_t id, void* user_data)
 {
+    (void) id;
+    (void) user_data;
+
     _clear_timer();
     _spdif_rx_capture_start();
     _set_timer_after_by_us(_spdif_rx_capture_timeout, capture_timeout_us);
@@ -564,6 +574,9 @@ static int _spdif_rx_analyze_capture(spdif_rx_samp_freq_t* samp_freq, bool* inve
 
 static int64_t _spdif_rx_decode_timeout(alarm_id_t id, void* user_data)
 {
+    (void) id;
+    (void) user_data;
+
     state = SPDIF_RX_STATE_NO_SIGNAL;
     if ((gcfg.flags & SPDIF_RX_FLAG_CALLBACKS) && on_lost_stable_func != NULL) {
         (*on_lost_stable_func)();
@@ -785,7 +798,7 @@ void spdif_rx_get_c_bits(void* ptr, size_t size, uint32_t offset)
 {
     uint32_t save = save_and_disable_interrupts(); // to avoid getting incomplete set of c_bits
     uint8_t* bptr = (uint8_t*) ptr;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
         if (offset + i >= SPDIF_BLOCK_SIZE / 16) {
             break;
         }

--- a/spdif_rx.c
+++ b/spdif_rx.c
@@ -487,6 +487,37 @@ static bool _spdif_rx_check_criteria(int samp_freq_id, int value, spdif_rx_samp_
     return false;
 }
 
+static int _spdif_count_leading_zeros(uint32_t v)
+{
+    if (v == 0) {
+        return 32;
+    }
+
+    uint8_t r = 0;
+
+    if ((v & 0xFFFF0000) == 0) {
+        v <<= 16;
+        r += 16;
+    }
+    if ((v & 0xFF000000) == 0) {
+        v <<= 8;
+        r += 8;
+    }
+    if ((v & 0xF0000000) == 0) {
+        v <<= 4;
+        r += 4;
+    }
+    if ((v & 0xC0000000) == 0) {
+        v <<= 2;
+        r += 2;
+    }
+    if ((v & 0x80000000) == 0) {
+        r += 1;
+    }
+
+    return r;
+}
+
 static int _spdif_rx_analyze_capture(spdif_rx_samp_freq_t* samp_freq, bool* inverted)
 {
     // sampled data analysis to calculate min_edge_interval, max_edge_interval for both 0 and 1
@@ -502,7 +533,7 @@ static int _spdif_rx_analyze_capture(spdif_rx_samp_freq_t* samp_freq, bool* inve
         int bit_pos = 0; // position within current dword
         int word_idx = 0;
         while (true) {
-            int r = __builtin_clz((cur) ? ~shift_reg : shift_reg); // leading zeros
+            int r = _spdif_count_leading_zeros((cur) ? ~shift_reg : shift_reg); // leading zeros
             if (r + bit_pos <= 31) { // found within remaining part of 32bit dword?
                 pos += r; // go to the found edge position
                 cur = 1 - cur; // toggle to other edge index

--- a/spdif_rx.c
+++ b/spdif_rx.c
@@ -489,33 +489,8 @@ static bool _spdif_rx_check_criteria(int samp_freq_id, int value, spdif_rx_samp_
 
 static int _spdif_count_leading_zeros(uint32_t v)
 {
-    if (v == 0) {
-        return 32;
-    }
-
-    uint8_t r = 0;
-
-    if ((v & 0xFFFF0000) == 0) {
-        v <<= 16;
-        r += 16;
-    }
-    if ((v & 0xFF000000) == 0) {
-        v <<= 8;
-        r += 8;
-    }
-    if ((v & 0xF0000000) == 0) {
-        v <<= 4;
-        r += 4;
-    }
-    if ((v & 0xC0000000) == 0) {
-        v <<= 2;
-        r += 2;
-    }
-    if ((v & 0x80000000) == 0) {
-        r += 1;
-    }
-
-    return r;
+    // to avoid the optimization issue, the separate wrapper function is needed for the care of the zero input case of __builtin_clz()
+    return value == 0 ? 32 : __builtin_clz(value);
 }
 
 static int _spdif_rx_analyze_capture(spdif_rx_samp_freq_t* samp_freq, bool* inverted)

--- a/spdif_rx.c
+++ b/spdif_rx.c
@@ -13,7 +13,6 @@
 #include "hardware/irq.h"
 #include "hardware/sync.h"
 #include "pico/stdlib.h"
-#include "pico/audio.h"
 #include "spdif_rx_capture.pio.h"
 #include "spdif_rx_48000.pio.h"
 #include "spdif_rx_96000.pio.h"
@@ -133,7 +132,6 @@ static uint32_t fifo_buff[SPDIF_RX_FIFO_SIZE];
 static uint32_t buff_wr_pre_ptr = 0;
 static uint32_t buff_wr_done_ptr = 0;
 static uint32_t buff_rd_ptr = 0;
-static uint32_t buff_count;
 
 static dma_channel_config dma_config0;
 static dma_channel_config dma_config1;

--- a/spdif_rx.c
+++ b/spdif_rx.c
@@ -490,7 +490,7 @@ static bool _spdif_rx_check_criteria(int samp_freq_id, int value, spdif_rx_samp_
 static int _spdif_count_leading_zeros(uint32_t v)
 {
     // to avoid the optimization issue, the separate wrapper function is needed for the care of the zero input case of __builtin_clz()
-    return value == 0 ? 32 : __builtin_clz(value);
+    return v == 0 ? 32 : __builtin_clz(v);
 }
 
 static int _spdif_rx_analyze_capture(spdif_rx_samp_freq_t* samp_freq, bool* inverted)


### PR DESCRIPTION
The GCC built-in function [`__builtin_clz`](https://gcc.gnu.org/onlinedocs/gcc/Bit-Operation-Builtins.html#index-_005f_005fbuiltin_005fclz) is documented as `Returns the number of leading 0-bits in x, starting at the most significant bit position. If x is 0, the result is undefined.`

The library function `_spdif_rx_analyze_capture` uses `__builtin_clz` expecting it will return `32` if the input is `0`. This happens to be true, but is not guaranteed. When this code is compiled with `-O2` or `-O3` the compiler sees this possible undefined behavior, marks `if (r + bit_pos <= 31)` as undefined as well, and ends up removing that entire code block. The compiled binary has only the `else` block and it never locks to the signal.

One way to fix it is to add `-fno-expensive-optimizations` to disable this check. Another fix is this PR that reimplements the built-in function with an explicit code path for `x == 0`.